### PR TITLE
use distr3 system file from swagger

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,7 +17,7 @@ Imports:
   base64enc (>= 0.1-3)
 Suggests:
   yaml (>= 2.1.14),
-  swagger (>= 3.9.2),
+  swagger (>= 3.20.3.9999),
   mime (>= 0.5),
   curl (>= 2.7),
   testthat (>= 2.0.0)

--- a/R/RestRserveApplication.R
+++ b/R/RestRserveApplication.R
@@ -360,7 +360,7 @@ RestRserveApplication = R6::R6Class(
 
       path_openapi = gsub("^/*", "", path_openapi)
 
-      self$add_static(path_swagger_assets, system.file("dist", package = "swagger"))
+      self$add_static(path_swagger_assets, system.file("dist3", package = "swagger"))
       write_swagger_ui_index_html(file_path, path_swagger_assets = path_swagger_assets, path_openapi = path_openapi)
       self$add_static(path, file_path)
       invisible(file_path)


### PR DESCRIPTION
The system directory from the swagger package used in the method `add_swagger_ui()` in `RestRserveApplication()` is outdated because that directory got renamed in the {swagger} package (see commit hashes in the commit message). This PR:

- updates the reference to the correct path.
- increases the minimal version dependency on {swagger} to ensure version compatibility.

I have not updated other references to OpenAPI versions here, I believe the {swagger} package uses 3.20.4 (source: https://github.com/rstudio/swagger/blob/67239fd0870d6c22671e1e42b81bdf0b561917e9/inst/dist3/package.json) and this project does not seem to use any specific version of the openAPI spec, so I assume it's fine.